### PR TITLE
fix cleanup code for channel entries with transport

### DIFF
--- a/dueca/UnifiedChannel.cxx
+++ b/dueca/UnifiedChannel.cxx
@@ -926,6 +926,7 @@ void UnifiedChannel::updateConfiguration(const UChannelCommRequest& msg)
 
     assert(msg.data0 < entries.size() && entries[msg.data0] != NULL);
     //  if (msg.data0 >= entries.size() || !entries[msg.data0]) break;
+    DEB("cleanup of entry " << msg.data0);
     delete entries[msg.data0]; entries[msg.data0] = NULL;
     break;
 
@@ -1212,9 +1213,12 @@ void UnifiedChannel::serviceLocal2(const LocationId location_id,
   assert(!config_changes.notEmpty());
 }
 
+// called by the timedservicer
 void UnifiedChannel::service()
 {
   if (masterp) {
+
+    // process all config requests here in the master
     if (config_requests.notEmpty()) {
 
       // in case the master end is local, process the requests

--- a/dueca/UnifiedChannelMaster.cxx
+++ b/dueca/UnifiedChannelMaster.cxx
@@ -16,7 +16,7 @@
 #include "DataClassRegistry.hxx"
 #include <debug.h>
 
-#define DEBPRINTLEVEL -1
+#define DEBPRINTLEVEL 0
 #include <debprint.h>
 
 DUECA_NS_START
@@ -323,7 +323,7 @@ void UnifiedChannelMaster::process(AsyncQueueMT<UChannelCommRequest>& req,
          * data1: provisional id (same as when created)
 
          Actions:
-         - make the entry invalid
+         - make the entry invalid (InvalidateEntryCmd to all ends)
          - add the entry to the cleaning stack
 
          The provisional id rather than the entry_id is used, because
@@ -370,8 +370,11 @@ void UnifiedChannelMaster::process(AsyncQueueMT<UChannelCommRequest>& req,
       */
     case UChannelCommRequest::CleanEntryConf: {
       entryid_type handle = req.front().data0;
+      DEB("Clean confirmation, #" << handle <<
+          ", round=" << req.front().data1);
       if (to_be_cleaned.front().round == req.front().data1 &&
           to_be_cleaned.front().entry == handle) {
+        DEB("Clean confirmation, matches round");
         if (--to_be_cleaned.front().stilldirty == 0) {
           reusable.push_back(handle);
           to_be_cleaned.pop_front();

--- a/dueca/vectorMT.hxx
+++ b/dueca/vectorMT.hxx
@@ -75,8 +75,8 @@ private:
 
 public:
 
-  vectorMT() :
-    N(0), data(new dataset(32U))
+  vectorMT(size_t reserve=32) :
+    N(0), data(new dataset(reserve))
   { }
 
   ~vectorMT()


### PR DESCRIPTION
Fixes problem where deleted entries in a channel are not properly cleaned when running on multiple nodes