### PR TITLE
Update MakefileTail.app

### DIFF
--- a/scripts/data/MakefileTail.app
+++ b/scripts/data/MakefileTail.app
@@ -6,6 +6,12 @@
 #       changes         : 040408 RvP added documentation generation
 # ============================================================================
 
+# restore build environment, needed for variables determined below
+ifneq ("$(wildcard dueca-buildenv-*)", "")
+    $(info using PATH, PKG_CONFIG_PATH, and PYTHONPATH from $(wildcard dueca-buildenv-*))
+    include $(wildcard dueca-buildenv-*)
+    SHELL := env PATH=$(PATH) PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) PYTHONPATH=$(PYTHONPATH) /bin/bash
+endif
 
 MACHINE :=	$(shell cat .machine)
 SUBDIRS :=      $(shell dueca-filtmods modules.$(MACHINE))
@@ -45,13 +51,6 @@ all : dueca_run.x buildenv
 
 cleanenv:
 	rm -f dueca-buildenv-*
-
-# restore build environment
-ifneq ("$(wildcard dueca-buildenv-*)", "")
-    $(info using PATH from $(wildcard dueca-buildenv-*))
-    include $(wildcard dueca-buildenv-*)
-    SHELL := env PATH=$(PATH) /bin/bash
-endif
 
 dueca_run.x : $(SUBDIRS) $(COMMDIRS)
 	$(LD) $(LDFLAGS) $(MODULES) \


### PR DESCRIPTION
When using an alternative DUECA version with the old Makefile setup (not cmake), e.g. installed in /opt/dueca-x-y-z/, all Makefile options must point there, e.g. -L/opt/dueca-x-y-z in DUECALIBS. These variables are filled by a combination of dueca-config (found through $PATH), pkg-config (dueca.pc found through $PKG_CONFIG_PATH, and possibly $PYTHONPATH. So these environment variables need to be set properly before filling the Makefile variables.