### PR TITLE
Use correct (abbreviated) URL for making projects

### DIFF
--- a/gitscripts/dueca-gproject.py
+++ b/gitscripts/dueca-gproject.py
@@ -407,7 +407,7 @@ class NewProject:
 
         # add the remote and push results
         if ns.remote:
-            repo.create_remote('origin', RootMap().urlToAbsolute(remoteurl))
+            repo.create_remote('origin', RootMap().urlToAbsolute(ns.remote))
             repo.git.push('--set-upstream', 'origin', 'master')
 
         print(f"Created new DUECA project {ns.name}")


### PR DESCRIPTION
dueca-gproject could no longer translate abbreviated remote URLs when making new projects after the remoteurl parameter was introduced and made relative. This fix at least allows command lines again like this: dueca-gproject new --name Test1 --remote dgrstudents:///Test1.git